### PR TITLE
Correct examples processing, remove doc

### DIFF
--- a/debian/x0-app.install
+++ b/debian/x0-app.install
@@ -12,7 +12,6 @@ python/getText.py var/www/vhosts/x0/python
 python/SQLMapper.py var/www/vhosts/x0/python
 python/Index.py var/www/vhosts/x0/python
 database/* var/lib/x0/database
-doc/* var/lib/x0/doc
 test/* var/lib/x0/test
 conf/* var/lib/x0/conf
 config/* var/lib/x0/config

--- a/debian/x0-app.postinst
+++ b/debian/x0-app.postinst
@@ -101,11 +101,14 @@ if [ "$1" = "configure" ]; then
 		echo "Processing example-config (static):${dirname}"
 		CONF_SQL_DIR="${EXAMPLE_CONFIG_DIR}/${dirname}/sql"
 		CONF_STATIC_DIR="${EXAMPLE_CONFIG_DIR}/${dirname}/static"
+		CONF_PYTHON_DIR="${EXAMPLE_CONFIG_DIR}/${dirname}/python"
 		DST_EXAMPLE_DIR="${APP_DIR}/examples/${dirname}"
 		mkdir -p ${DST_EXAMPLE_DIR}
 		cp ${CONF_STATIC_DIR}/* ${DST_EXAMPLE_DIR}/
+		cp ${CONF_PYTHON_DIR}/* ${APP_PYTHONDIR}/
 		cp ${APP_DIR}/static/*.css ${DST_EXAMPLE_DIR}/
 		cp -r ${APP_DIR}/static/fontawesome ${DST_EXAMPLE_DIR}/
+		cp APP_PYTHONDIR
 	done
 
 	# restart apache


### PR DESCRIPTION
Closes #52. Example script dir including `/python` subdir gets processed now.