### PR TITLE
Correct Package Dependencies For Ubuntu PostgreSQL 16

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,21 +3,21 @@ Section: javascript
 Priority: extra
 Maintainer: Claus Prüfer <pruefer@webcodex.de>
 Standards-Version: 4.5.1
-Build-Depends: debhelper (>= 11)
+Build-Depends: debhelper (>=11)
 Homepage: http://click-it.online/
 Vcs-Git: git://github.com/WEBcodeX1/x0
 
 Package: x0-app
 Section: javascript
 Architecture: all
-Depends: python3 (>= 3.4), python3-pip (>= 18), libpq-dev (>= 13.0), postgresql-client, apache2 (>= 2.4), libapache2-mod-wsgi-py3 (>= 3.3), python3-psycopg2 (>= 2.9) , ${misc:Depends}
+Depends: python3 (>=3.4), python3-pip (>=18), libpq-dev (>=16.0), postgresql-client, apache2 (>=2.4), libapache2-mod-wsgi-py3 (>=3.3), python3-psycopg2 (>=2.9) , ${misc:Depends}
 Description: True, serverless OOP JavaScript SPA browser-framework.
  JavaScript Single Page Application browser framework.
 
 Package: x0-db
 Section: database
 Architecture: all
-Depends: python3 (>= 3.4), postgresql (>=14), ${misc:Depends}
+Depends: python3 (>=3.4), postgresql (>=16), postgresql (<<17), ${misc:Depends}
 Description: True, serverless OOP JavaScript SPA browser-framework.
  JavaScript Single Page Application browser framework.
  Database component.
@@ -25,14 +25,14 @@ Description: True, serverless OOP JavaScript SPA browser-framework.
 Package: x0-db-install
 Section: database
 Architecture: all
-Depends: python3 (>= 3.4), postgresql-client (>=14), ${misc:Depends}
+Depends: python3 (>=3.4), postgresql-client (>=16), ${misc:Depends}
 Description: Database installer package for x0 system database.
  Database installer package for x0 system database.
 
 Package: x0-db-install-tpl
 Section: database
 Architecture: all
-Depends: python3 (>= 3.4), postgresql-client (>=14), ${misc:Depends}
+Depends: python3 (>=3.4), postgresql-client (>=16), ${misc:Depends}
 Description: Transparent Database installer package template.
  Used to transparently install database in distributed (docker / kubernetes)
  scalable environments.
@@ -40,13 +40,13 @@ Description: Transparent Database installer package template.
 Package: x0-test
 Section: misc
 Architecture: all
-Depends: python3 (>= 3.4), python3-selenium, python3-pytest, python3-sphinx, python3-sphinx-rtd-theme, python3-openstackclient, python3-cinderclient, python3-designateclient, python3-heatclient, python3-swiftclient, ${misc:Depends}
+Depends: python3 (>=3.4), python3-selenium, python3-pytest, python3-sphinx, python3-sphinx-rtd-theme, python3-openstackclient, python3-cinderclient, python3-designateclient, python3-heatclient, python3-swiftclient, ${misc:Depends}
 Description: Integration-Tests execution and documentation generation.
  Integration-Tests execution and documentation generation.
 
 Package: x0-msg-server
 Section: server
 Architecture: all
-Depends: python3 (>= 3.4), apache2 (>= 2.4), libapache2-mod-wsgi-py3 (>= 3.3), ${misc:Depends}
+Depends: python3 (>=3.4), apache2 (>=2.4), libapache2-mod-wsgi-py3 (>=3.3), ${misc:Depends}
 Description: Tiny messaging server written in Python3.
  Tiny messaging server written in Python3.


### PR DESCRIPTION
Closes #77.

Debian debuild references correct ubuntu 24.04 shipped PostgreSQL 16 packages now.