### PR TITLE
Reduce debug-output in high-frequented parts

### DIFF
--- a/www/sysBaseDOMElement.js
+++ b/www/sysBaseDOMElement.js
@@ -98,7 +98,7 @@ sysBaseDOMElement.prototype.removeDOMParentElement = function()
 
 sysBaseDOMElement.prototype.removeDOMElement = function()
 {
-    console.debug('::removeDOMElement DOMDivElement:%s', this.DOMDivElement.id);
+    //console.debug('::removeDOMElement DOMDivElement:%s', this.DOMDivElement.id);
     try {
         document.getElementById(this.DOMDivElement.id).remove();
     }
@@ -117,7 +117,7 @@ sysBaseDOMElement.prototype.setDOMElementValue = function()
     //console.debug('::setDOMElementValue this:%o', this);
     if (this.DOMValue != null && this.DOMValue !== undefined) {
         var divElement = document.getElementById(this.DOMObjectID);
-        console.debug('::setDOMElementValue divElement:%o', divElement);
+        //console.debug('::setDOMElementValue divElement:%o', divElement);
         if (divElement != null && divElement !== undefined) {
             divElement.innerHTML = this.DOMValue;
         }
@@ -389,7 +389,9 @@ sysBaseDOMElement.prototype.DOMaddEventListener = function(Type, Destination)
     try {
         const ElementID = this.DOMObjectID;
         const Element = document.getElementById(ElementID);
-        Element.addEventListener(Type, Destination);
+        if (Element != null) {
+            Element.addEventListener(Type, Destination);
+        }
     }
     catch(err) {
         console.debug('::addEventListener err:%s ObjectID:%s DOMObjectID:%s', err, this.ObjectID, this.DOMObjectID);

--- a/www/sysBaseObject.js
+++ b/www/sysBaseObject.js
@@ -307,7 +307,7 @@ sysBaseObject.prototype.removeParent = function()
 
 sysBaseObject.prototype.getObjectData = function()
 {
-    console.debug('::BaseObject getObjectData() this:%o', this);
+    //console.debug('::BaseObject getObjectData() this:%o', this);
     return this.RuntimeGetDataFunc();
 }
 

--- a/www/sysFactory.js
+++ b/www/sysFactory.js
@@ -181,7 +181,7 @@ sysFactory.prototype.getLastScreenObject = function() {
 //------------------------------------------------------------------------------
 
 sysFactory.prototype.getObjectByID = function(ObjectID) {
-    console.debug('::getObjectByID this.Screens:%o', this.Screens);
+    //console.debug('::getObjectByID this.Screens:%o', this.Screens);
     for (ScreenID in this.Screens) {
         const ScreenObj = this.Screens[ScreenID];
         const ResultObj = ScreenObj.HierarchyRootObject.getObjectByID(ObjectID);

--- a/www/sysObjFormfieldItem.js
+++ b/www/sysObjFormfieldItem.js
@@ -60,7 +60,7 @@ sysFormfieldItem.prototype.FormItemInit = function()
 
     this.DBColumn = Attributes.DBColumn;
 
-    console.debug('FormItem Attributes:%o', Attributes);
+    //console.debug('FormItem Attributes:%o', Attributes);
 
     if (this.JSONConfig !== undefined && this.JSONConfig.InstancePrefix !== undefined) {
         this.InstancePrefix = this.JSONConfig.InstancePrefix;
@@ -144,11 +144,11 @@ sysFormfieldItem.prototype.setupEventListener = function()
 
 sysFormfieldItem.prototype.FormItemGetValue = function()
 {
-    console.debug('::FormItemGetValue DOMObjectID:%s ObjectID:%s', this.DOMObjectID, this.ObjectID);
+    //console.debug('::FormItemGetValue DOMObjectID:%s ObjectID:%s', this.DOMObjectID, this.ObjectID);
     try {
         const FormElement = document.getElementById(this.ObjectID);
         const FormValue = FormElement.value;
-        console.debug('::FormItemGetValue Element:%o Value:%s', FormElement, FormValue);
+        //console.debug('::FormItemGetValue Element:%o Value:%s', FormElement, FormValue);
         return FormValue;
     }
     catch(err) {
@@ -350,8 +350,7 @@ sysFormfieldItem.prototype.resetStyle = function()
 
 sysFormfieldItem.prototype.reset = function()
 {
-    console.debug('FormfieldItem reset method call Object:%o', this);
-
+    //console.debug('FormfieldItem reset method call Object:%o', this);
     const Attributes = this.JSONConfig.Attributes;
     this.RuntimeSetDataFunc(
         (Attributes.Value !== undefined ? Attributes.Value : '')


### PR DESCRIPTION
# Pull Request

## Description

Some framework code sections generate too much debug-output when highly frequented (e.g. object set / get value or similar). They must be commented out.

## Type of Change

- [x] Enhancement

## Additional Notes

It could also be a performance enhancement.
