### PR TITLE
Convert Line Breaks From Win To Unix

### DIFF
--- a/kubernetes/setup/Setup.py
+++ b/kubernetes/setup/Setup.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/python3
+#!/usr/bin/python3
 
 import os
 import sys


### PR DESCRIPTION
# Pull Request

## Description
Convert line breaks from win (\r\n) to unix-style (\n only). This should make `Setup.py` run on both Linux and Windows.

## Type of Change

- [x] Bug fix
