### PR TITLE
Add forgotten sysObjTreeSimple.js initial loading

### DIFF
--- a/python/Index.py
+++ b/python/Index.py
@@ -58,6 +58,7 @@ HTMLTop = """<!DOCTYPE html>
   <script type="text/javascript" src="/sysObjFormfieldList.js"></script>
   <script type="text/javascript" src="/sysObjDynRadioList.js"></script>
   <script type="text/javascript" src="/sysObjOpenCloseContainer.js"></script>
+  <script type="text/javascript" src="/sysObjTreeSimple.js"></script>
   <script type="text/javascript" src="/sysGridGenerator.js"></script>
   <script type="text/javascript" src="/sysFactory.js"></script>
   <script type="text/javascript" src="/sysAsyncNotify.js"></script>


### PR DESCRIPTION
# Pull Request

## Description

Fix `Index.py` not containing `sysObjTreeSimple.js` initial loading.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix
- [x] Quick fix
