### PR TITLE
Add replacement routine, change from "sh" to "bash", fixes #135

### DIFF
--- a/kubernetes/export/terraform-export.sh
+++ b/kubernetes/export/terraform-export.sh
@@ -28,7 +28,7 @@ for namespace in "${namespaces[@]}"; do
     done
 done
 
-for cfgfile in "${dstpath}/*.tf"; do
-    sed -i -e 's/cluster\_i\_ps/cluster\_ips/g' ${cfgfile}
+for cfgfile in ${dstpath}/*.tf; do
+    sed -i -e 's/cluster\_i\_ps/cluster\_ips/g' "${cfgfile}"
 done
 

--- a/kubernetes/export/terraform-export.sh
+++ b/kubernetes/export/terraform-export.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 dstpath=$1
 if [ -z "$1" ]; then
@@ -27,3 +27,8 @@ for namespace in "${namespaces[@]}"; do
         kubectl get ${object} -n ${namespace} -o yaml | k2tf -o ${dstpath}/${namespace}-${object}.tf
     done
 done
+
+for cfgfile in "${dstpath}/*.tf"; do
+    sed -i -e 's/cluster\_i\_ps/cluster\_ips/g' ${cfgfile}
+done
+


### PR DESCRIPTION
# Pull Request

## Description

- Change script execution binary from `sh` to `bash`.
- Add replacement routine (replace `cluster_i_ps` by `cluster_ips`

## Related Issue

Fixes #135.

## Type of Change

- [x] Bug fix
